### PR TITLE
LF-40840 image compression

### DIFF
--- a/gdal/frmts/webp/webpdataset.cpp
+++ b/gdal/frmts/webp/webpdataset.cpp
@@ -695,6 +695,9 @@ WEBPDataset::CreateCopy( const char * pszFilename, GDALDataset *poSrcDS,
     if (sConfig.lossless)
         sPicture.use_argb = 1;
 #endif
+#if WEBP_ENCODER_ABI_VERSION >= 0x0209
+    FETCH_AND_SET_OPTION_INT("EXACT", exact, 0, 1);
+#endif
 
     if (!WebPValidateConfig(&sConfig))
     {
@@ -907,6 +910,9 @@ void GDALRegister_WEBP()
 "   <Option name='PARTITIONS' type='int' description='log2(number of token partitions) in [0..3]' default='0'/>\n"
 #if WEBP_ENCODER_ABI_VERSION >= 0x0002
 "   <Option name='PARTITION_LIMIT' type='int' description='quality degradation allowed to fit the 512k limit on prediction modes coding (0=no degradation, 100=full)' default='0'/>\n"
+#endif
+#if WEBP_ENCODER_ABI_VERSION >= 0x0209
+"   <Option name='EXACT' type='int' description='preserve the exact RGB values under transparent area. off=0, on=1' default='0'/>\n"
 #endif
 "</CreationOptionList>\n" );
 

--- a/gdal/swig/makefile.vc
+++ b/gdal/swig/makefile.vc
@@ -14,12 +14,12 @@ python: gdalvars
         cd python
         -del setup_vars.ini
         echo 'GNM_ENABLED=$(INCLUDE_GNM_FRMTS)' > setup_vars.ini
-        $(SWIG) -python -modern -new_repr -o extensions/gdalconst_wrap.c -outdir osgeo ..\include\gdalconst.i
-        $(SWIG) -c++ -python -modern -new_repr -I../include/python -I../include/python/docs -o extensions/gdal_wrap.cpp -outdir osgeo ..\include\gdal.i
-        $(SWIG) -c++ -python -modern -new_repr -I../include/python -I../include/python/docs -o extensions/osr_wrap.cpp -outdir osgeo ..\include\osr.i
-        $(SWIG) -c++ -python -modern -new_repr -I../include/python -I../include/python/docs -o extensions/ogr_wrap.cpp -outdir osgeo ..\include\ogr.i
-        $(SWIG) -c++ -python -modern -new_repr -I../include/python -I../include/python/docs -o extensions/gnm_wrap.cpp -outdir osgeo ..\include\gnm.i
-        $(SWIG) -c++ -python -modern -new_repr -I../include/python -I../include/python/docs -o extensions/gdal_array_wrap.cpp -outdir osgeo ..\include\gdal_array.i
+        $(SWIG) -python -modern -new_repr -threads -o extensions/gdalconst_wrap.c -outdir osgeo ..\include\gdalconst.i
+        $(SWIG) -c++ -python -modern -new_repr -threads -I../include/python -I../include/python/docs -o extensions/gdal_wrap.cpp -outdir osgeo ..\include\gdal.i
+        $(SWIG) -c++ -python -modern -new_repr -threads -I../include/python -I../include/python/docs -o extensions/osr_wrap.cpp -outdir osgeo ..\include\osr.i
+        $(SWIG) -c++ -python -modern -new_repr -threads -I../include/python -I../include/python/docs -o extensions/ogr_wrap.cpp -outdir osgeo ..\include\ogr.i
+        $(SWIG) -c++ -python -modern -new_repr -threads -I../include/python -I../include/python/docs -o extensions/gnm_wrap.cpp -outdir osgeo ..\include\gnm.i
+        $(SWIG) -c++ -python -modern -new_repr -threads -I../include/python -I../include/python/docs -o extensions/gdal_array_wrap.cpp -outdir osgeo ..\include\gdal_array.i
         $(PYDIR)\python.exe setup.py build
 	cd ..
 


### PR DESCRIPTION
This PR makes two changes:
1. Support the 'exact' option in the WEBP dataset. This was already reviewed in https://freya.seequent.com/projects/REARCHITECT/repos/build_scripts/pull-requests/254/overview.
2. Build GDAL python wrappers with the -threads argument, which enables releasing the GIL when possible. The GNUmakefile's already passing this flag.